### PR TITLE
Compatibility with React Router RC1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,14 @@ react-router-reverse
 
 Components and helpers for route reversal in react-router@1.x.x.
 
-## \<ReverseLink to={routeName} params={params} {...props}/\>
+## \<ReverseLink to={routeName} params={params} routes={routes} {...props}/\>
 
 Wraps react-router's ```Link``` component to handle route reversal.
 
-As with ```Link```, ```router``` must be part of the owner component's context.
+The routes collection, which is passed in to your route-handler component's props by React Router, must be passed in to ```ReverseLink```.
+
+Note: Older versions of React Router added ```router``` to the context, but this has been removed as of ```rc1```.
+
 
 ```js
 import React from 'react';
@@ -15,11 +18,14 @@ import {ReverseLink} from 'react-router-reverse';
 
 
 class MyComponent extends React.Component {
+  static propTypes: {
+    routes: React.PropTypes.array.isRequired,
+  }
   render() {
     return (
       <nav>
-        <ReverseLink to="landing"/>Home</ReverseLink>
-        <ReverseLink to="detail" params={{id: 5}}>Detail</ReverseLink>
+        <ReverseLink to="landing" routes={this.props.routes}/>Home</ReverseLink>
+        <ReverseLink to="detail" params={{id: 5}} routes={this.props.routes}>Detail</ReverseLink>
       </nav>
     );
   }
@@ -36,11 +42,11 @@ import {reverse} from 'react-router-reverse';
 
 
 class MyComponent extends React.Component {
-  static contextTypes = {
-    router: React.PropTypes.object.isRequired
-  };
+  static propTypes: {
+    routes: React.PropTypes.array.isRequired,
+  }
   transitionHome = () => {
-    const path = reverse(router.routes, 'landing');
+    const path = reverse(this.props.routes, 'landing');
     this.router.transition(path);
   }
   render() {

--- a/lib/components.js
+++ b/lib/components.js
@@ -39,7 +39,7 @@ function createReverseLink(React, Link) {
       key: 'propTypes',
       value: {
         to: React.PropTypes.string,
-        routes: React.PropTypes.object.isRequired,
+        routes: React.PropTypes.array.isRequired,
         params: React.PropTypes.object
       },
       enumerable: true

--- a/lib/components.js
+++ b/lib/components.js
@@ -19,91 +19,28 @@ function _inherits(subClass, superClass) { if (typeof superClass !== 'function' 
 var _utils = require('./utils');
 
 function createReverseLink(React, Link) {
-  var Provider = (function (_React$Component) {
-    _inherits(Provider, _React$Component);
-
-    function Provider() {
-      var _this = this;
-
-      _classCallCheck(this, Provider);
-
-      _get(Object.getPrototypeOf(Provider.prototype), 'constructor', this).apply(this, arguments);
-
-      this.getChildContext = function () {
-        return {
-          router: _this.props.router
-        };
-      };
-    }
-
-    _createClass(Provider, [{
-      key: 'render',
-      value: function render() {
-        return this.props.children;
-      }
-    }], [{
-      key: 'propTypes',
-      value: {
-        children: React.PropTypes.any,
-        router: React.PropTypes.object.isRequired
-      },
-      enumerable: true
-    }, {
-      key: 'childContextTypes',
-      value: {
-        router: React.PropTypes.object.isRequired
-      },
-      enumerable: true
-    }]);
-
-    return Provider;
-  })(React.Component);
-
-  return (function (_React$Component2) {
-    _inherits(ReverseLink, _React$Component2);
+  return (function (_React$Component) {
+    _inherits(ReverseLink, _React$Component);
 
     function ReverseLink() {
-      var _this2 = this;
-
       _classCallCheck(this, ReverseLink);
 
       _get(Object.getPrototypeOf(ReverseLink.prototype), 'constructor', this).apply(this, arguments);
-
-      this.getChildContext = function () {
-        return {
-          router: _this2.context.router
-        };
-      };
     }
 
     _createClass(ReverseLink, [{
       key: 'render',
       value: function render() {
-        var path = (0, _utils.reverse)(this.context.router.routes, this.props.to, this.props.params);
+        var path = (0, _utils.reverse)(this.props.routes, this.props.to, this.props.params);
 
-        return React.createElement(
-          Provider,
-          { router: this.context.router },
-          React.createElement(Link, _extends({}, this.props, { to: path }))
-        );
+        return React.createElement(Link, _extends({}, this.props, { to: path }));
       }
     }], [{
-      key: 'contextTypes',
-      value: {
-        router: React.PropTypes.object.isRequired
-      },
-      enumerable: true
-    }, {
       key: 'propTypes',
       value: {
         to: React.PropTypes.string,
+        routes: React.PropTypes.object.isRequired,
         params: React.PropTypes.object
-      },
-      enumerable: true
-    }, {
-      key: 'childContextTypes',
-      value: {
-        router: React.PropTypes.object
       },
       enumerable: true
     }]);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, '__esModule', {
 });
 exports.reverse = reverse;
 
-var _reactRouterLibURLUtils = require('react-router/lib/URLUtils');
+var _reactRouterLibPatternUtils = require('react-router/lib/PatternUtils');
 
 function reverse(routes, name, params) {
   var parentPath = arguments.length <= 3 || arguments[3] === undefined ? '' : arguments[3];
@@ -16,7 +16,7 @@ function reverse(routes, name, params) {
     var currentPath = parentPath + (route.path || '/');
 
     if (name == route.name) {
-      return (0, _reactRouterLibURLUtils.formatPattern)(currentPath, params);
+      return (0, _reactRouterLibPatternUtils.formatPattern)(currentPath, params);
     };
 
     if (route.childRoutes) {

--- a/package.json
+++ b/package.json
@@ -6,15 +6,16 @@
   "devDependencies": {
     "babel": "^5.4.7",
     "babel-runtime": "^5.8.20",
+    "history": "^1.12.1",
     "jsdom": "^3.1.2",
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
     "react": "^0.13.3",
-    "react-router": "^1.0.0-beta3"
+    "react-router": "^1.0.0-rc1"
   },
   "peerDependencies": {
     "react": "^0.13.3",
-    "react-router": "^1.0.0-beta3"
+    "react-router": "^1.0.0-rc1"
   },
   "scripts": {
     "build:lib": "babel --stage 0 src --out-dir lib",

--- a/src/components.es6
+++ b/src/components.es6
@@ -1,48 +1,16 @@
 import {reverse} from './utils';
 
-
 export function createReverseLink(React, Link) {
-  class Provider extends React.Component {
-    static propTypes = {
-      children: React.PropTypes.any,
-      router: React.PropTypes.object.isRequired
-    };
-    static childContextTypes = {
-      router: React.PropTypes.object.isRequired
-    };
-    getChildContext = () => {
-      return {
-        router: this.props.router
-      };
-    }
-    render() {
-      return this.props.children;
-    }
-  }
-
   return class ReverseLink extends React.Component {
-    static contextTypes = {
-      router: React.PropTypes.object.isRequired
-    };
     static propTypes = {
       to: React.PropTypes.string,
+      routes: React.PropTypes.object.isRequired,
       params: React.PropTypes.object
     };
-    static childContextTypes = {
-      router: React.PropTypes.object
-    };
-    getChildContext = () => {
-      return {
-        router: this.context.router
-      };
-    }
     render() {
-      const path = reverse(this.context.router.routes, this.props.to,
-                           this.props.params)
+      const path = reverse(this.props.routes, this.props.to, this.props.params)
 
-      return <Provider router={this.context.router}>
-        <Link {...this.props} to={path}/>
-      </Provider>
+      return <Link {...this.props} to={path}/>
     }
   }
 }

--- a/src/components.es6
+++ b/src/components.es6
@@ -4,7 +4,7 @@ export function createReverseLink(React, Link) {
   return class ReverseLink extends React.Component {
     static propTypes = {
       to: React.PropTypes.string,
-      routes: React.PropTypes.object.isRequired,
+      routes: React.PropTypes.array.isRequired,
       params: React.PropTypes.object
     };
     render() {

--- a/src/utils.es6
+++ b/src/utils.es6
@@ -1,4 +1,4 @@
-import {formatPattern} from 'react-router/lib/URLUtils';
+import {formatPattern} from 'react-router/lib/PatternUtils';
 
 
 export function reverse(routes, name, params, parentPath='') {

--- a/test.es6
+++ b/test.es6
@@ -19,10 +19,11 @@ describe('ReverseLink', () => {
 
   class TestComponent extends React.Component {
     render() {
+      debugger;
       return <nav>
-        <ReverseLink to="landing">Home</ReverseLink>
-        <ReverseLink to="detail" params={{id: 5}}>Detail</ReverseLink>
-        <ReverseLink to="detail-edit" params={{id: 10, user: 'kev'}}>
+        <ReverseLink to="landing" routes={this.props.routes}>Home</ReverseLink>
+        <ReverseLink to="detail" params={{id: 5}} routes={this.props.routes}>Detail</ReverseLink>
+        <ReverseLink to="detail-edit" params={{id: 10, user: 'kev'}} routes={this.props.routes}>
           Edit Post
         </ReverseLink>
       </nav>
@@ -67,6 +68,7 @@ describe('ReverseLink', () => {
 
 
 describe('ReverseLink nested context', () => {
+  debugger;
   jsdom();
   const React = require('react/addons');
   const {createMemoryHistory} = require('history');
@@ -83,8 +85,8 @@ describe('ReverseLink nested context', () => {
     render() {
       return <header>
         <nav>
-          <li><ReverseLink to="landing">Home</ReverseLink></li>
-          <li><ReverseLink to="detail">Detail</ReverseLink></li>
+          <li><ReverseLink to="landing" routes={this.props.routes}>Home</ReverseLink></li>
+          <li><ReverseLink to="detail" routes={this.props.routes}>Detail</ReverseLink></li>
         </nav>
       </header>
     }
@@ -93,7 +95,7 @@ describe('ReverseLink nested context', () => {
   class TestComponent extends React.Component {
     render() {
       return <div>
-        <Header/>
+        <Header {...this.props}/>
       </div>
     }
   }

--- a/test.es6
+++ b/test.es6
@@ -15,7 +15,7 @@ const jsdom = mochaJsdom.bind(this, {skipWindowCheck: true});
 describe('ReverseLink', () => {
   jsdom();
   const React = require('react/addons');
-  const history = require('react-router/lib/MemoryHistory');
+  const {createMemoryHistory} = require('history');
 
   class TestComponent extends React.Component {
     render() {
@@ -29,7 +29,7 @@ describe('ReverseLink', () => {
     }
   }
 
-  const router = <Router history={new history('/')}>
+  const router = <Router history={createMemoryHistory()}>
     <Route name="app" component={TestComponent}>
       <Route name="landing" path="/" component={TestComponent}/>
       <Route name="detail" path="/detail/:id" component={TestComponent}>
@@ -69,7 +69,7 @@ describe('ReverseLink', () => {
 describe('ReverseLink nested context', () => {
   jsdom();
   const React = require('react/addons');
-  const history = require('react-router/lib/MemoryHistory');
+  const {createMemoryHistory} = require('history');
 
   class App extends React.Component {
     render() {
@@ -98,7 +98,7 @@ describe('ReverseLink nested context', () => {
     }
   }
 
-  const router = <Router history={new history('/')}>
+  const router = <Router history={createMemoryHistory()}>
     <Route name="app" component={App}>
       <Route name="landing" path="/" component={TestComponent}/>
       <Route name="detail" path="/detail" component={TestComponent}/>

--- a/test.es6
+++ b/test.es6
@@ -19,7 +19,6 @@ describe('ReverseLink', () => {
 
   class TestComponent extends React.Component {
     render() {
-      debugger;
       return <nav>
         <ReverseLink to="landing" routes={this.props.routes}>Home</ReverseLink>
         <ReverseLink to="detail" params={{id: 5}} routes={this.props.routes}>Detail</ReverseLink>
@@ -68,7 +67,6 @@ describe('ReverseLink', () => {
 
 
 describe('ReverseLink nested context', () => {
-  debugger;
   jsdom();
   const React = require('react/addons');
   const {createMemoryHistory} = require('history');

--- a/test.js
+++ b/test.js
@@ -51,7 +51,6 @@ describe('ReverseLink', function () {
     _createClass(TestComponent, [{
       key: 'render',
       value: function render() {
-        debugger;
         return React.createElement(
           'nav',
           null,
@@ -120,7 +119,6 @@ describe('ReverseLink', function () {
 });
 
 describe('ReverseLink nested context', function () {
-  debugger;
   jsdom();
   var React = require('react/addons');
 

--- a/test.js
+++ b/test.js
@@ -51,22 +51,23 @@ describe('ReverseLink', function () {
     _createClass(TestComponent, [{
       key: 'render',
       value: function render() {
+        debugger;
         return React.createElement(
           'nav',
           null,
           React.createElement(
             _libIndex.ReverseLink,
-            { to: 'landing' },
+            { to: 'landing', routes: this.props.routes },
             'Home'
           ),
           React.createElement(
             _libIndex.ReverseLink,
-            { to: 'detail', params: { id: 5 } },
+            { to: 'detail', params: { id: 5 }, routes: this.props.routes },
             'Detail'
           ),
           React.createElement(
             _libIndex.ReverseLink,
-            { to: 'detail-edit', params: { id: 10, user: 'kev' } },
+            { to: 'detail-edit', params: { id: 10, user: 'kev' }, routes: this.props.routes },
             'Edit Post'
           )
         );
@@ -119,6 +120,7 @@ describe('ReverseLink', function () {
 });
 
 describe('ReverseLink nested context', function () {
+  debugger;
   jsdom();
   var React = require('react/addons');
 
@@ -172,7 +174,7 @@ describe('ReverseLink nested context', function () {
               null,
               React.createElement(
                 _libIndex.ReverseLink,
-                { to: 'landing' },
+                { to: 'landing', routes: this.props.routes },
                 'Home'
               )
             ),
@@ -181,7 +183,7 @@ describe('ReverseLink nested context', function () {
               null,
               React.createElement(
                 _libIndex.ReverseLink,
-                { to: 'detail' },
+                { to: 'detail', routes: this.props.routes },
                 'Detail'
               )
             )
@@ -208,7 +210,7 @@ describe('ReverseLink nested context', function () {
         return React.createElement(
           'div',
           null,
-          React.createElement(Header, null)
+          React.createElement(Header, this.props)
         );
       }
     }]);

--- a/test.js
+++ b/test.js
@@ -34,7 +34,10 @@ var jsdom = _mochaJsdom2['default'].bind(undefined, { skipWindowCheck: true });
 describe('ReverseLink', function () {
   jsdom();
   var React = require('react/addons');
-  var history = require('react-router/lib/MemoryHistory');
+
+  var _require = require('history');
+
+  var createMemoryHistory = _require.createMemoryHistory;
 
   var TestComponent = (function (_React$Component) {
     _inherits(TestComponent, _React$Component);
@@ -75,7 +78,7 @@ describe('ReverseLink', function () {
 
   var router = React.createElement(
     _reactRouter.Router,
-    { history: new history('/') },
+    { history: createMemoryHistory() },
     React.createElement(
       _reactRouter.Route,
       { name: 'app', component: TestComponent },
@@ -118,7 +121,10 @@ describe('ReverseLink', function () {
 describe('ReverseLink nested context', function () {
   jsdom();
   var React = require('react/addons');
-  var history = require('react-router/lib/MemoryHistory');
+
+  var _require2 = require('history');
+
+  var createMemoryHistory = _require2.createMemoryHistory;
 
   var App = (function (_React$Component2) {
     _inherits(App, _React$Component2);
@@ -212,7 +218,7 @@ describe('ReverseLink nested context', function () {
 
   var router = React.createElement(
     _reactRouter.Router,
-    { history: new history('/') },
+    { history: createMemoryHistory() },
     React.createElement(
       _reactRouter.Route,
       { name: 'app', component: App },


### PR DESCRIPTION
It looks like there were a few updates in `react-router@1.0.0-rc1` that broke a few things (the biggest one being removing `router` from `context`), so I took a pass through.

Thanks a ton for making this :+1:
